### PR TITLE
add description fill to useful_link table, and require all its fills

### DIFF
--- a/db/migration/20201101143041_initial_tables.js
+++ b/db/migration/20201101143041_initial_tables.js
@@ -3,8 +3,8 @@ exports.up = function(knex) {
   return knex.schema
   .createTable("images", (table) => {
       table.increments("id")
-      table.text("name")
-      table.binary("image")
+      table.text("name").notNullable()
+      table.binary("image").notNullable()
       table.text("alt_text")
   })
   .createTable("tags", (table) => {
@@ -28,9 +28,10 @@ exports.up = function(knex) {
   })
   .createTable("useful_links", table => {
       table.increments("id")
-      table.text("name")
-      table.text("url")
-      table.text("tag_name")
+      table.text("name").notNullable()
+      table.text("description").notNullable()
+      table.text("url").notNullable()
+      table.text("tag_name").notNullable()
         .unsigned()
         .references("tags.name")
         .onDelete("RESTRICT")


### PR DESCRIPTION
Add description field to useful_link table because the seed_data feature needs it.